### PR TITLE
FIX: use django-admin instead of manage.py which is missing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-python manage.py migrate --settings=$DJANGO_SETTINGS_MODULE --noinput
-python manage.py collectstatic --settings=$DJANGO_SETTINGS_MODULE --noinput
+django-admin migrate --settings=$DJANGO_SETTINGS_MODULE --noinput
+django-admin collectstatic --settings=$DJANGO_SETTINGS_MODULE --noinput
 django-admin compilemessages
 python -m gunicorn --bind=0.0.0.0 --timeout 600 rechnung.wsgi


### PR DESCRIPTION
This still does not fix the issue that django is not aware where the packages are.

```
django-admin check
Traceback (most recent call last):
  File "/usr/local/bin/django-admin", line 8, in <module>
    sys.exit(execute_from_command_line())
             ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
    ~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python3.13/site-packages/django/apps/config.py", line 178, in create
    mod = import_module(mod_path)
  File "/usr/local/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'invoice'
```