### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Segelzwerg/Rechnung/security/code-scanning/4](https://github.com/Segelzwerg/Rechnung/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the jobs. Based on the actions and steps in the workflow, the `contents: read` permission is sufficient, as the jobs only involve linting and security checks without modifying the repository. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
