### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  secrets: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Segelzwerg/Rechnung/security/code-scanning/2](https://github.com/Segelzwerg/Rechnung/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository files.
- `secrets: read` for accessing the `CODECOV_TOKEN` secret.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
